### PR TITLE
OMX live stream support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "http": "0.0.0",
-    "omx-manager": "0.0.3",
+    "omx-manager": "0.1.4",
     "serve-index": "^1.7.3",
     "socket.io": "^1.4.5"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@
             </form>
             <button id="folder-select" class="pure-button">Choose folder</button>
             <button id="file-list" class="pure-button">Fetch file list</button>
+            <button id="select-stream" class="pure-button">Open Stream</button>
             <button id="shutdown" class="pure-button">Shutdown</button>
         </header>
         <div class="pure-g">

--- a/public/index.html
+++ b/public/index.html
@@ -28,10 +28,12 @@
             <form class="pure-form">
                 <input id="folder" type="text"></input>
             </form>
-            <button id="folder-select" class="pure-button">Choose folder</button>
-            <button id="file-list" class="pure-button">Fetch file list</button>
-            <button id="select-stream" class="pure-button">Open Stream</button>
-            <button id="shutdown" class="pure-button">Shutdown</button>
+	    <span>
+                <button id="folder-select" class="pure-button">Choose folder</button>
+                <button id="file-list" class="pure-button">Fetch file list</button>
+                <button id="select-stream" class="pure-button">Open Stream</button>
+                <button id="shutdown" class="pure-button">Shutdown</button>
+            </span>
         </header>
         <div class="pure-g">
 

--- a/public/index.js
+++ b/public/index.js
@@ -72,18 +72,27 @@ $(document).ready(function(){
   // Extract the folder from the query string and set the folder box based on this
   var folder = getQueryVariable('folder');
   $("input#folder").val(folder);
+  function getFolder() {
+    return folder;
+  }
 
   // Get the files if they exist
   getFiles(socket);
 
   // Add a handler for the button which requests the folder list
   $("button#file-list").click(function(){
+    folder = $("input#folder").val();
     getFiles(socket);
   });
 
   // Add a handler for the folder select button to take you to the folder browser
   $("button#folder-select").click(function(){
     window.location.replace("/filesystem");
+  });
+
+  $("button#select-stream").click(function(){
+    streamPath = $("input#folder").val();
+    getStream(socket);
   });
 
   // Add a handler for the play button
@@ -97,7 +106,11 @@ $(document).ready(function(){
       // If the item is not disabled
       if($(li).hasClass('ui-state-disabled') === false){
         // Push it onto the list
-        playList.push($(li).text().substring(7));
+        if ($(li).text().startsWith("reorder")) {
+          playList.push(getFolder() + "/" + $(li).text().substring(7));
+	} else {
+          playList.push($(li).text());
+	}
       };
     });
     // Finally, push the list to the backend, along with the associated options
@@ -128,6 +141,13 @@ $(document).ready(function(){
     window.location.replace('/public/shutdown.html')
     socket.emit('shutdown');
   });
+
+  function getStream(socket) {
+    $("div#file-list ul").empty();
+    var stream = $("input#folder").val();
+    var listItem = $("<li>", {class: 'ui-state-default'}).text(stream);
+    $("div#file-list ul").append(listItem);
+  };
 
   function getFiles(socket) {
 

--- a/public/index.scss
+++ b/public/index.scss
@@ -17,6 +17,10 @@ header {
     }
 }
 
+input#folder {
+    width: 35%;
+}
+
 body {
     @include primary-text-color-dark;
 }
@@ -64,3 +68,25 @@ div#controls {
         }
     }
 }
+
+@media (max-width: 720px) and (-webkit-min-device-pixel-ratio: 2)
+{
+  header > span {
+    width: 100%;
+    display: inherit;
+    padding-top: 0.4em;
+  }
+  input#folder { width: 100%; }
+}
+
+@media (max-width: 800px) and (-webkit-max-device-pixel-ratio: 2)
+{
+  header > span {
+    width: 100%;
+    display: inherit;
+    padding-top: 0.4em;
+  }
+  input#folder { width: 100%; }
+}
+
+


### PR DESCRIPTION
I've added some basic support to the RasPlayer interface to allow the user to specify a URL path for a live stream (Tested using RTMP links, but should work OK with any URL parameter omx can handle).

I've also updated the `omx-manager` library to the most recent version (0.1.4).  I can cherry-pick that portion out as a separate pull request if you prefer.